### PR TITLE
Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,35 @@
-# Tempo Frontend challenge
+# Frontend challenge
 
-# Solution Improvement
+## Solution Improvement
 
-### Describe what you have improved in the solution
+* One of the things that I considered an improvement was move all logic from components, keeping them cleaner, easier to mantain and to test.
+* Some variables name was changed to better reflect what is used for. For example: `mapArray` was changed to `mapTeamMembersToList`.
+* Created unit tests to cover almost all scenarios, like `events`, `data rendering` and `navigation`.
+Separeted some code by context, for example types and api, to keep code organized.
 
-## To Run the project you must run:
+## Instructions
 
-```
+* Create new components that will be simple and stateless as possible.
+* Any logic should be kept in pages or any state management library.
+* Cover as much scenarios as possibles with unit tests.
+* Create variables that shows what this is used for.
+
+## To Run the project you must run
+
+```javascript
 npm install
 ```
 
-## after the installation finished, you can run:
+## after the installation finished, you can run
 
-```
+```javascript
 npm start
 ```
 
-#### The project will open in your browser with the following url http://localhost:3000;
+### The project will open in your browser with the following url http://localhost:3000
 
-## To run the tests yo must run
+## To run the tests you must run
 
-```
+```javascript
 npm run test
 ```

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,8 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Web site created using create-react-app" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet">
+
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import TeamOverview from './pages/TeamOverview';
 import Teams from './pages/Teams';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,21 +1,2 @@
-import {Teams, TeamOverview, UserData} from 'types';
-
-const getData = async (path = '') => {
-    const url = `${process.env.REACT_APP_API_BASE_URL}/${path}`;
-    const res = await fetch(url);
-    const json = await res.json();
-
-    return json;
-};
-
-export const getTeams = (): Promise<Teams[]> => {
-    return getData('teams');
-};
-
-export const getTeamOverview = (teamId: string): Promise<TeamOverview> => {
-    return getData(`teams/${teamId}`);
-};
-
-export const getUserData = (userId: string): Promise<UserData> => {
-    return getData(`users/${userId}`);
-};
+export * from './teams';
+export * from './users';

--- a/src/api/teams.ts
+++ b/src/api/teams.ts
@@ -1,0 +1,10 @@
+import {TeamOverview, Teams} from 'types';
+import {fetchData} from 'utils/httpRequest';
+
+export const getTeams = (): Promise<Teams[]> => {
+    return fetchData('teams');
+};
+
+export const getTeamOverview = (teamId: string): Promise<TeamOverview> => {
+    return fetchData(`teams/${teamId}`);
+};

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,0 +1,6 @@
+import {UserData} from '../types';
+import {fetchData} from '../utils/httpRequest';
+
+export const getUserData = (userId: string): Promise<UserData> => {
+    return fetchData(`users/${userId}`);
+};

--- a/src/components/Card/__tests__/testCard.tsx
+++ b/src/components/Card/__tests__/testCard.tsx
@@ -12,7 +12,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('Card', () => {
     it('should render card with single column', () => {
-        var columns = [{key: 'columnKey', value: 'columnValue'}];
+        const columns = [{key: 'columnKey', value: 'columnValue'}];
         render(<Card columns={columns} />);
 
         expect(screen.getByText('columnKey')).toBeInTheDocument();
@@ -20,7 +20,7 @@ describe('Card', () => {
     });
 
     it('should render card with multiple columns', () => {
-        var columns = [
+        const columns = [
             {key: 'columnKey1', value: 'columnValue1'},
             {key: 'columnKey2', value: 'columnValue2'},
             {key: 'columnKey3', value: 'columnValue3'},

--- a/src/components/Card/__tests__/testCard.tsx
+++ b/src/components/Card/__tests__/testCard.tsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import {fireEvent, render, screen} from '@testing-library/react';
-import {Teams} from 'types';
 import Card from '..';
-
-const mockUseNavigate = jest.fn();
-
-jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockUseNavigate,
-}));
 
 describe('Card', () => {
     it('should render card with single column', () => {
@@ -37,29 +29,34 @@ describe('Card', () => {
         expect(screen.getByText('columnKey4')).toBeInTheDocument();
     });
 
-    it('should navigate when card is clicked and navigation is enabled', () => {
-        const navProps = {
-            id: '1',
-            name: 'Team 1',
-        } as Teams;
+    it('should emit click event when card is clicked and navigation is enabled', () => {
+        const mockOnClick = jest.fn();
+
         render(
             <Card
                 columns={[{key: 'columnKey', value: 'columnValue'}]}
-                url="path"
-                navigationProps={navProps}
+                hasNavigation
+                onClick={mockOnClick}
             />
         );
 
         fireEvent.click(screen.getByText('columnKey'));
 
-        expect(mockUseNavigate).toHaveBeenCalledWith('path', {state: navProps});
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
     });
 
-    it('should not navigate when card is clicked and navigation is disabled', () => {
-        render(<Card columns={[{key: 'columnKey', value: 'columnValue'}]} hasNavigation={false} />);
+    it('should not emit click event when card is clicked and navigation is disabled', () => {
+        const mockOnClick = jest.fn();
+        render(
+            <Card
+                columns={[{key: 'columnKey', value: 'columnValue'}]}
+                hasNavigation={false}
+                onClick={mockOnClick}
+            />
+        );
 
         fireEvent.click(screen.getByText('columnKey'));
 
-        expect(mockUseNavigate).not.toHaveBeenCalled();
+        expect(mockOnClick).not.toHaveBeenCalled();
     });
 });

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -25,7 +25,7 @@ const Card = ({id, columns, hasNavigation = false, onClick}: Props): JSX.Element
             data-testid={`cardContainer-${id}`}
             onClick={handleOnClick}
         >
-            {columns.map(({key: columnKey, value}) => (
+            {columns?.map(({key: columnKey, value}) => (
                 <p key={columnKey}>
                     <strong>{columnKey}</strong>&nbsp;{value}
                 </p>

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,5 +1,5 @@
 import React, {MouseEventHandler} from 'react';
-import {Container} from './styles';
+import {Circle, Column, ColumnKey, ColumnValue, Container} from './styles';
 
 interface Props {
     id?: string;
@@ -12,6 +12,13 @@ interface Props {
 }
 
 const Card = ({id, columns, hasNavigation = false, onClick}: Props): JSX.Element => {
+    const initials = columns[0]?.value
+        .split(' ')
+        .map(word => word.charAt(0))
+        .slice(0, 2)
+        .join('')
+        .toUpperCase();
+
     const handleOnClick: MouseEventHandler<HTMLDivElement> = event => {
         event.preventDefault();
         if (hasNavigation && onClick) {
@@ -25,10 +32,12 @@ const Card = ({id, columns, hasNavigation = false, onClick}: Props): JSX.Element
             data-testid={`cardContainer-${id}`}
             onClick={handleOnClick}
         >
+            <Circle>{initials}</Circle>
             {columns?.map(({key: columnKey, value}) => (
-                <p key={columnKey}>
-                    <strong>{columnKey}</strong>&nbsp;{value}
-                </p>
+                <Column key={columnKey}>
+                    <ColumnKey>{columnKey}</ColumnKey>
+                    <ColumnValue>{value}</ColumnValue>
+                </Column>
             ))}
         </Container>
     );

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -1,40 +1,29 @@
-import * as React from 'react';
-import {useNavigate} from 'react-router-dom';
-import {Teams, UserData} from 'types';
+import React, {MouseEventHandler} from 'react';
 import {Container} from './styles';
 
 interface Props {
     id?: string;
-    url?: string;
     columns: Array<{
         key: string;
         value: string;
     }>;
     hasNavigation?: boolean;
-    navigationProps?: UserData | Teams;
+    onClick?: MouseEventHandler<HTMLDivElement>;
 }
 
-const Card = ({
-    id,
-    columns,
-    url,
-    hasNavigation = true,
-    navigationProps = null,
-}: Props): JSX.Element => {
-    const navigate = useNavigate();
+const Card = ({id, columns, hasNavigation = false, onClick}: Props): JSX.Element => {
+    const handleOnClick: MouseEventHandler<HTMLDivElement> = event => {
+        event.preventDefault();
+        if (hasNavigation && onClick) {
+            onClick(event);
+        }
+    };
 
     return (
         <Container
-            data-testid={`cardContainer-${id}`}
             hasNavigation={hasNavigation}
-            onClick={(e: Event) => {
-                if (hasNavigation) {
-                    navigate(url, {
-                        state: navigationProps,
-                    });
-                }
-                e.preventDefault();
-            }}
+            data-testid={`cardContainer-${id}`}
+            onClick={handleOnClick}
         >
             {columns.map(({key: columnKey, value}) => (
                 <p key={columnKey}>

--- a/src/components/Card/styles.ts
+++ b/src/components/Card/styles.ts
@@ -3,13 +3,46 @@ import styled from 'styled-components';
 export const Container = styled.div<{hasNavigation: boolean}>`
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid black;
-    background: #ddd;
-    padding: 20px;
-    width: 250px;
-    max-height: 200px;
+    align-items: flex-start;
+    margin: 1rem 0;
+    padding: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background: white;
+    width: 15vw;
+    min-width: 120px;
     cursor: ${props => (props.hasNavigation ? 'pointer' : 'default')};
-    margin: 5px;
+    &:hover {
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    }
+`;
+
+export const Circle = styled.div`
+    display: flex;
+    justify-content: center;
+    align-self: center;
+    align-items: center;
+    width: 64px;
+    height: 64px;
+    margin-bottom: 16px;
+    background-color: var(--primary-color);
+    border-radius: 50%;
+    font-size: 24px;
+    font-weight: bold;
+    color: white;
+`;
+
+export const Column = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 1rem 0;
+`;
+
+export const ColumnKey = styled.p`
+    font-size: 1rem;
+`;
+
+export const ColumnValue = styled.p`
+    font-size: 1.2rem;
+    font-weight: bold;
 `;

--- a/src/components/Filter/__tests__/testFilter.tsx
+++ b/src/components/Filter/__tests__/testFilter.tsx
@@ -1,0 +1,34 @@
+import React, {ChangeEvent} from 'react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import Filter from '..';
+
+describe('Filter', () => {
+    beforeAll(() => {
+        jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+        jest.clearAllTimers();
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    });
+
+    it('should render with correct label', () => {
+        render(<Filter label="Filter" onChange={() => {}} />);
+
+        expect(screen.getByText('Filter')).toBeInTheDocument();
+    });
+
+    it('fires the onChange event when the input value changes', () => {
+        const mockOnChange = jest.fn();
+        render(<Filter label="Label" onChange={mockOnChange} />);
+        const filterInput = screen.getByLabelText('Label');
+
+        const event = {target: {value: 'Test Value'}} as ChangeEvent<HTMLInputElement>;
+
+        fireEvent.change(filterInput, event);
+        expect(mockOnChange).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/components/Filter/index.tsx
+++ b/src/components/Filter/index.tsx
@@ -1,0 +1,24 @@
+import React, {ChangeEventHandler} from 'react';
+import {FilterContainer, Label, Input} from './styles';
+
+interface Props {
+    label: string;
+    onChange: ChangeEventHandler<HTMLInputElement>;
+}
+
+const Filter = ({label, onChange}: Props) => {
+    const handleChange: ChangeEventHandler<HTMLInputElement> = event => {
+        if (onChange) {
+            onChange(event);
+        }
+    };
+
+    return (
+        <FilterContainer onChange={handleChange}>
+            <Label htmlFor="filter">{label}</Label>
+            <Input id="filter" />
+        </FilterContainer>
+    );
+};
+
+export default Filter;

--- a/src/components/Filter/styles.ts
+++ b/src/components/Filter/styles.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const FilterContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    margin: 1rem 0;
+`;
+
+export const Input = styled.input`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem;
+`;
+
+export const Label = styled.label`
+    font-size: 1.2rem;
+    font-weight: bold;
+`;

--- a/src/components/Filter/styles.ts
+++ b/src/components/Filter/styles.ts
@@ -12,9 +12,22 @@ export const Input = styled.input`
     align-items: center;
     justify-content: space-between;
     padding: 1rem;
+    border: none;
+    border-radius: 15px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 0.2s ease-in-out;
+    font-size: 16px;
+    line-height: 1.5;
+    width: 50vw;
+
+    &:focus {
+        outline: none;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+    }
 `;
 
 export const Label = styled.label`
     font-size: 1.2rem;
     font-weight: bold;
+    margin-bottom: 0.5rem;
 `;

--- a/src/components/GlobalComponents.ts
+++ b/src/components/GlobalComponents.ts
@@ -2,7 +2,6 @@ import styled from 'styled-components';
 
 export const Container = styled.div`
     flex: 1;
-    margin: 20px;
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {useNavigate} from 'react-router-dom';
 import {HeaderContainer, NavigationHeader, BackButton, Title} from './styles';
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {useNavigate} from 'react-router-dom';
-import {HeaderContainer, NavigationHeader, BackButton, Title} from './styles';
+import {HeaderContainer, BackButton, Title} from './styles';
 
 interface Props {
     title: string;
@@ -9,20 +9,15 @@ interface Props {
 
 const Header = ({title, showBackButton = true}: Props) => {
     const navigate = useNavigate();
+
+    const handleOnBackClick = () => {
+        navigate(-1);
+    };
+
     return (
         <HeaderContainer>
-            <NavigationHeader>
-                {showBackButton && (
-                    <BackButton
-                        onClick={() => {
-                            navigate(-1);
-                        }}
-                    >
-                        🔙
-                    </BackButton>
-                )}
-                <Title>{title}</Title>
-            </NavigationHeader>
+            {showBackButton && <BackButton onClick={handleOnBackClick}>Back</BackButton>}
+            <Title>{title}</Title>
         </HeaderContainer>
     );
 };

--- a/src/components/Header/styles.ts
+++ b/src/components/Header/styles.ts
@@ -2,30 +2,29 @@ import styled from 'styled-components';
 
 export const HeaderContainer = styled.div`
     height: 100px;
-    margin: 10px;
     display: flex;
-    flex-direction: column;
+    width: 100%;
     align-items: center;
-    justify-content: space-between;
+    justify-content: center;
+    background: var(--secondary-color);
+    color: white;
+    gap: 1rem;
 `;
 
 export const Title = styled.h1``;
-
-export const NavigationHeader = styled.div`
-    display: flex;
-    align-items: center;
-    justify-content: center;
-`;
 
 export const BackButton = styled.button`
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: 5px;
-    font-weight: bold;
-    font-size: 18px;
+    font-size: 1.2rem;
+    padding: 1rem;
+    background: var(--primary-color);
+    border-radius: 15px;
+    border: 0;
+    color: white;
     cursor: pointer;
-    width: 40px;
-    height: 40px;
-    outline: 0;
+    &:hover {
+        transform: scale(1.1);
+    }
 `;

--- a/src/components/List/__tests__/testList.tsx
+++ b/src/components/List/__tests__/testList.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
+import {ListItem} from 'types';
 import List from '..';
 
 jest.mock('react-router-dom', () => ({
@@ -8,7 +9,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 describe('List', () => {
-    it('should render spinner and not render items when it is loading', () => {
+    it('should render single card when single item', () => {
         const items = [
             {
                 id: '1',
@@ -20,27 +21,8 @@ describe('List', () => {
                 ],
             },
         ];
-        render(<List isLoading items={items} />);
+        render(<List items={items} />);
 
-        expect(screen.getByTestId('spinner')).toBeInTheDocument();
-        expect(screen.queryByTestId('cardContainer')).not.toBeInTheDocument();
-    });
-
-    it('should not render spinner and render items when it is not loading', () => {
-        const items = [
-            {
-                id: '1',
-                columns: [
-                    {
-                        key: 'columnKey1',
-                        value: 'columnValue1',
-                    },
-                ],
-            },
-        ];
-        render(<List isLoading={false} items={items} />);
-
-        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
         expect(screen.getByTestId('cardContainer-1')).toBeInTheDocument();
     });
 
@@ -65,9 +47,55 @@ describe('List', () => {
                 ],
             },
         ];
-        render(<List isLoading={false} items={items} />);
+        render(<List items={items} />);
 
         expect(screen.getByTestId('cardContainer-1')).toBeInTheDocument();
         expect(screen.getByTestId('cardContainer-2')).toBeInTheDocument();
+    });
+
+    it('should emit click event when card is clicked and navigation is enabled', () => {
+        const mockOnClick = jest.fn();
+
+        const items = [
+            {
+                id: '1',
+                url: 'url',
+                navigationProps: {},
+                columns: [
+                    {
+                        key: 'columnKey1',
+                        value: 'columnValue1',
+                    },
+                ],
+            } as ListItem,
+        ];
+        render(<List items={items} hasNavigation onClick={mockOnClick} />);
+
+        fireEvent.click(screen.getByText('columnKey1'));
+
+        expect(mockOnClick).toHaveBeenCalledTimes(1);
+        expect(mockOnClick).toHaveBeenCalledWith('url', {state: {}});
+    });
+
+    it('should not emit click event when card is clicked and navigation is disabled', () => {
+        const mockOnClick = jest.fn();
+        const items = [
+            {
+                id: '1',
+                url: 'url',
+                navigationProps: {},
+                columns: [
+                    {
+                        key: 'columnKey1',
+                        value: 'columnValue1',
+                    },
+                ],
+            } as ListItem,
+        ];
+        render(<List items={items} hasNavigation={false} onClick={mockOnClick} />);
+
+        fireEvent.click(screen.getByText('columnKey1'));
+
+        expect(mockOnClick).not.toHaveBeenCalled();
     });
 });

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,32 +1,35 @@
 import * as React from 'react';
-import {ListItem} from 'types';
+import {NavigateOptions} from 'react-router-dom';
+import {ListItem, Teams, UserData} from 'types';
 import Card from '../Card';
-import {Spinner} from '../Spinner';
 import {Container} from './styles';
 
 interface Props {
     items?: ListItem[];
     hasNavigation?: boolean;
-    isLoading: boolean;
+    onClick?: (url: string, navigationProps: NavigateOptions) => void;
 }
 
-const List = ({items, hasNavigation = true, isLoading}: Props) => {
+const List = ({items, hasNavigation = true, onClick}: Props) => {
+    const handleCardClick = (url: string, navigationProps: UserData | Teams) => {
+        if (hasNavigation && onClick) {
+            onClick(url, {state: navigationProps});
+        }
+    };
+
     return (
         <Container>
-            {isLoading && <Spinner />}
-            {!isLoading &&
-                items.map(({url, id, columns, navigationProps}, index) => {
-                    return (
-                        <Card
-                            key={`${id}-${index}`}
-                            id={id}
-                            columns={columns}
-                            navigationProps={navigationProps}
-                            hasNavigation={hasNavigation}
-                            url={url}
-                        />
-                    );
-                })}
+            {items.map(({url, id, columns, navigationProps}, index) => {
+                return (
+                    <Card
+                        key={`${id}-${index}`}
+                        id={id}
+                        columns={columns}
+                        onClick={() => handleCardClick(url, navigationProps)}
+                        hasNavigation
+                    />
+                );
+            })}
         </Container>
     );
 };

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {NavigateOptions} from 'react-router-dom';
 import {ListItem, Teams, UserData} from 'types';
 import Card from '../Card';

--- a/src/components/List/styles.ts
+++ b/src/components/List/styles.ts
@@ -7,4 +7,5 @@ export const Container = styled.div`
     flex-wrap: wrap;
     justify-content: center;
     align-items: center;
+    gap: 0.5rem;
 `;

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import styled, {keyframes} from 'styled-components';
 
 const spinnerAnimation = keyframes`

--- a/src/components/Spinner/index.tsx
+++ b/src/components/Spinner/index.tsx
@@ -17,6 +17,7 @@ const SpinnerBody = styled.div`
     border-top-color: #3b82f6;
     border-radius: 50%;
     animation: ${spinnerAnimation} 800ms linear infinite;
+    margin: 4rem 0;
 `;
 
 export const Spinner = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -6,4 +6,10 @@
 
 body {
   font-family: 'Roboto', sans-serif;
+  background: #EEEEEE;
+}
+
+:root {
+  --primary-color: #00BEC8;
+  --secondary-color: #00325A;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,7 @@
   padding: 0;
   outline: 0;
 }
+
+body {
+  font-family: 'Roboto', sans-serif;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from 'App';
 import 'index.css';

--- a/src/pages/TeamOverview.tsx
+++ b/src/pages/TeamOverview.tsx
@@ -1,67 +1,28 @@
 import React, {ChangeEvent, useEffect, useMemo, useState} from 'react';
-import {useLocation, useParams} from 'react-router-dom';
+import {NavigateOptions, useLocation, useNavigate, useParams} from 'react-router-dom';
 import {ListItem, UserData} from 'types';
-import {getTeamOverview, getUserData} from '../api';
-import Card from '../components/Card';
-import {Container} from '../components/GlobalComponents';
-import Header from '../components/Header';
-import List from '../components/List';
-import Filter from '../components/Filter';
+import {getTeamOverview, getUserData} from 'api';
+import Card from 'components/Card';
+import {Container} from 'components/GlobalComponents';
+import Header from 'components/Header';
+import List from 'components/List';
+import Filter from 'components/Filter';
+import {mapUserToListItem} from 'utils/mappers';
+import {Spinner} from 'components/Spinner';
 
-var mapTeamMembersToList = (users: UserData[]) => {
-    // TODO: Rename variable
-    return users.map(u => {
-        var columns = [
-            {
-                key: 'Name',
-                value: `${u.firstName} ${u.lastName}`,
-            },
-            {
-                key: 'Display Name',
-                value: u.displayName,
-            },
-            {
-                key: 'Location',
-                value: u.location,
-            },
-        ];
-        return {
-            id: u.id,
-            url: `/user/${u.id}`,
-            columns,
-            navigationProps: u,
-        };
-    }) as ListItem[];
-};
-
-var mapTLead = tlead => {
-    var columns = [
-        {
-            key: 'Team Lead',
-            value: '',
-        },
-        {
-            key: 'Name',
-            value: `${tlead.firstName} ${tlead.lastName}`,
-        },
-        {
-            key: 'Display Name',
-            value: tlead.displayName,
-        },
-        {
-            key: 'Location',
-            value: tlead.location,
-        },
-    ];
-    return <Card columns={columns} url={`/user/${tlead.id}`} navigationProps={tlead} />;
+const mapTeamMembersToList = (users: UserData[]) => {
+    return users.map(user => mapUserToListItem(user)) as ListItem[];
 };
 
 const filterTeamMembers = (teamMembers: UserData[], filter: string) => {
+    if (!teamMembers) {
+        return [];
+    }
     const compareTeamMemberNameWithFilter = (teamMemberName: string) =>
         teamMemberName.toUpperCase().includes(filter.toUpperCase());
     return filter
-        ? teamMembers.filter(teamMember => compareTeamMemberNameWithFilter(teamMember.displayName))
-        : teamMembers ?? [];
+        ? teamMembers?.filter(teamMember => compareTeamMemberNameWithFilter(teamMember.displayName))
+        : teamMembers;
 };
 
 interface PageState {
@@ -70,35 +31,53 @@ interface PageState {
 }
 
 const TeamOverview = () => {
+    const navigate = useNavigate();
     const location = useLocation();
     const {teamId} = useParams();
     const [pageData, setPageData] = useState<PageState>({});
     const [isLoading, setIsLoading] = useState<boolean>(true);
-    const [filter, setFilter] = useState<string | null>(null);
+    const [filter, setFilter] = useState<string>('');
 
     const filteredTeamMembers = useMemo(
         () => filterTeamMembers(pageData.teamMembers, filter),
         [pageData, filter]
     );
 
-    const mappedTeamMembersToList = useMemo(
+    const mappedTeamMembersToListItem = useMemo(
         () => mapTeamMembersToList(filteredTeamMembers ?? []),
         [filteredTeamMembers]
     );
 
+    const mappedTeamLead = useMemo(() => mapUserToListItem(pageData.teamLead), [pageData]);
+
     const handleOnFilterChange = (event: ChangeEvent<HTMLInputElement>) =>
         setFilter(event.target.value);
 
+    const handleCardClick = (url: string, navigationProps: NavigateOptions) => {
+        navigate(url, navigationProps);
+    };
+
+    const teamLeadCard = () => {
+        return (
+            <Card
+                onClick={() =>
+                    handleCardClick(mappedTeamLead.url, {state: mappedTeamLead.navigationProps})
+                }
+                hasNavigation
+                columns={mappedTeamLead.columns}
+            />
+        );
+    };
+
     useEffect(() => {
-        var getTeamUsers = async () => {
+        const getTeamUsers = async () => {
             const {teamLeadId, teamMemberIds = []} = await getTeamOverview(teamId);
             const teamLead = await getUserData(teamLeadId);
 
-            const teamMembers = [];
-            for (var teamMemberId of teamMemberIds) {
-                const data = await getUserData(teamMemberId);
-                teamMembers.push(data);
-            }
+            const teamMembers = await Promise.all(
+                teamMemberIds.map(teamMemberId => getUserData(teamMemberId))
+            );
+
             setPageData({
                 teamLead,
                 teamMembers,
@@ -112,8 +91,9 @@ const TeamOverview = () => {
         <Container>
             <Header title={`Team ${location.state.name}`} />
             <Filter label="Search Team Member" onChange={handleOnFilterChange} />
-            {!isLoading && mapTLead(pageData.teamLead)}
-            <List items={mappedTeamMembersToList} isLoading={isLoading} />
+            {isLoading && <Spinner />}
+            {!isLoading && teamLeadCard()}
+            <List onClick={handleCardClick} hasNavigation items={mappedTeamMembersToListItem} />
         </Container>
     );
 };

--- a/src/pages/TeamOverview.tsx
+++ b/src/pages/TeamOverview.tsx
@@ -69,6 +69,19 @@ const TeamOverview = () => {
         );
     };
 
+    const teamMembersList = () => {
+        return <List onClick={handleCardClick} hasNavigation items={mappedTeamMembersToListItem} />;
+    };
+
+    const renderTeamOverview = () => {
+        return (
+            <React.Fragment>
+                {teamLeadCard()}
+                {teamMembersList()}
+            </React.Fragment>
+        );
+    };
+
     useEffect(() => {
         const getTeamUsers = async () => {
             const {teamLeadId, teamMemberIds = []} = await getTeamOverview(teamId);
@@ -92,8 +105,7 @@ const TeamOverview = () => {
             <Header title={`Team ${location.state.name}`} />
             <Filter label="Search Team Member" onChange={handleOnFilterChange} />
             {isLoading && <Spinner />}
-            {!isLoading && teamLeadCard()}
-            <List onClick={handleCardClick} hasNavigation items={mappedTeamMembersToListItem} />
+            {!isLoading && renderTeamOverview()}
         </Container>
     );
 };

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,28 +1,13 @@
 import React, {ChangeEvent, useEffect, useMemo, useState} from 'react';
-import {ListItem, Teams as TeamsList} from 'types';
-import {getTeams as fetchTeams} from '../api';
-import Header from '../components/Header';
-import List from '../components/List';
-import {Container} from '../components/GlobalComponents';
-import Filter from '../components/Filter';
-
-// TODO: Change every possible var to const
-var mapTeamsToList = (teams: TeamsList[]) => {
-    return teams.map(team => {
-        var columns = [
-            {
-                key: 'Name',
-                value: team.name,
-            },
-        ];
-        return {
-            id: team.id,
-            url: `/team/${team.id}`,
-            columns,
-            navigationProps: team,
-        } as ListItem;
-    });
-};
+import {Teams as TeamsList} from 'types';
+import {getTeams as fetchTeams} from 'api';
+import Header from 'components/Header';
+import List from 'components/List';
+import {Container} from 'components/GlobalComponents';
+import Filter from 'components/Filter';
+import {mapTeamsToListItem} from 'utils/mappers';
+import {Spinner} from 'components/Spinner';
+import {NavigateOptions, useNavigate} from 'react-router-dom';
 
 const filterTeams = (teams: TeamsList[], filter: string) => {
     const compareTeamNameWithFilter = (teamName: string) =>
@@ -31,13 +16,17 @@ const filterTeams = (teams: TeamsList[], filter: string) => {
 };
 
 const Teams = () => {
-    // TODO: Remove any from useState
-    const [teams, setTeams] = useState<any>([]);
-    const [isLoading, setIsLoading] = useState<any>(true);
-    const [filter, setFilter] = useState<string | null>(null);
+    const navigate = useNavigate();
+    const [teams, setTeams] = useState<TeamsList[]>([]);
+    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [filter, setFilter] = useState<string>('');
 
     const filteredTeams = useMemo(() => filterTeams(teams, filter), [teams, filter]);
-    const mappedTeamsToList = useMemo(() => mapTeamsToList(filteredTeams), [filteredTeams]);
+    const mappedTeamsToList = useMemo(() => mapTeamsToListItem(filteredTeams), [filteredTeams]);
+
+    const handleCardClick = (url: string, navigationProps: NavigateOptions) => {
+        navigate(url, navigationProps);
+    };
 
     const handleOnFilterChange = (event: ChangeEvent<HTMLInputElement>) =>
         setFilter(event.target.value);
@@ -56,7 +45,10 @@ const Teams = () => {
         <Container>
             <Header title="Teams" showBackButton={false} />
             <Filter label="Search Project" onChange={event => handleOnFilterChange(event)} />
-            <List items={mappedTeamsToList} isLoading={isLoading} />
+            {isLoading && <Spinner />}
+            {!isLoading && (
+                <List onClick={handleCardClick} hasNavigation items={mappedTeamsToList} />
+            )}
         </Container>
     );
 };

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -1,11 +1,13 @@
-import * as React from 'react';
+import React, {ChangeEvent, useEffect, useMemo, useState} from 'react';
 import {ListItem, Teams as TeamsList} from 'types';
 import {getTeams as fetchTeams} from '../api';
 import Header from '../components/Header';
 import List from '../components/List';
 import {Container} from '../components/GlobalComponents';
+import Filter from '../components/Filter';
 
-var MapT = (teams: TeamsList[]) => {
+// TODO: Change every possible var to const
+var mapTeamsToList = (teams: TeamsList[]) => {
     return teams.map(team => {
         var columns = [
             {
@@ -22,13 +24,28 @@ var MapT = (teams: TeamsList[]) => {
     });
 };
 
-const Teams = () => {
-    const [teams, setTeams] = React.useState<any>([]);
-    const [isLoading, setIsLoading] = React.useState<any>(true);
+const filterTeams = (teams: TeamsList[], filter: string) => {
+    const compareTeamNameWithFilter = (teamName: string) =>
+        teamName.toUpperCase().includes(filter.toUpperCase());
+    return filter ? teams.filter(team => compareTeamNameWithFilter(team.name)) : teams;
+};
 
-    React.useEffect(() => {
+const Teams = () => {
+    // TODO: Remove any from useState
+    const [teams, setTeams] = useState<any>([]);
+    const [isLoading, setIsLoading] = useState<any>(true);
+    const [filter, setFilter] = useState<string | null>(null);
+
+    const filteredTeams = useMemo(() => filterTeams(teams, filter), [teams, filter]);
+    const mappedTeamsToList = useMemo(() => mapTeamsToList(filteredTeams), [filteredTeams]);
+
+    const handleOnFilterChange = (event: ChangeEvent<HTMLInputElement>) =>
+        setFilter(event.target.value);
+
+    useEffect(() => {
         const getTeams = async () => {
             const response = await fetchTeams();
+
             setTeams(response);
             setIsLoading(false);
         };
@@ -38,7 +55,8 @@ const Teams = () => {
     return (
         <Container>
             <Header title="Teams" showBackButton={false} />
-            <List items={MapT(teams)} isLoading={isLoading} />
+            <Filter label="Search Project" onChange={event => handleOnFilterChange(event)} />
+            <List items={mappedTeamsToList} isLoading={isLoading} />
         </Container>
     );
 };

--- a/src/pages/Teams.tsx
+++ b/src/pages/Teams.tsx
@@ -33,9 +33,13 @@ const Teams = () => {
 
     useEffect(() => {
         const getTeams = async () => {
-            const response = await fetchTeams();
+            try {
+                const teamsResponse = await fetchTeams();
 
-            setTeams(response);
+                setTeams(teamsResponse);
+            } catch (error) {
+                setTeams([]);
+            }
             setIsLoading(false);
         };
         getTeams();
@@ -44,10 +48,12 @@ const Teams = () => {
     return (
         <Container>
             <Header title="Teams" showBackButton={false} />
-            <Filter label="Search Project" onChange={event => handleOnFilterChange(event)} />
             {isLoading && <Spinner />}
             {!isLoading && (
-                <List onClick={handleCardClick} hasNavigation items={mappedTeamsToList} />
+                <React.Fragment>
+                    <Filter label="Search Project" onChange={handleOnFilterChange} />
+                    <List onClick={handleCardClick} hasNavigation items={mappedTeamsToList} />
+                </React.Fragment>
             )}
         </Container>
     );

--- a/src/pages/UserOverview.tsx
+++ b/src/pages/UserOverview.tsx
@@ -1,36 +1,17 @@
-import * as React from 'react';
+import React, {useMemo} from 'react';
 import {useLocation} from 'react-router-dom';
-import {UserData} from 'types';
-import Card from '../components/Card';
-import {Container} from '../components/GlobalComponents';
-import Header from '../components/Header';
-
-var mapU = (user: UserData) => {
-    var columns = [
-        {
-            key: 'Name',
-            value: `${user.firstName} ${user.lastName}`,
-        },
-        {
-            key: 'Display Name',
-            value: user.displayName,
-        },
-        {
-            key: 'Location',
-            value: user.location,
-        },
-    ];
-    return <Card columns={columns} hasNavigation={false} navigationProps={user} />;
-};
+import Card from 'components/Card';
+import {Container} from 'components/GlobalComponents';
+import Header from 'components/Header';
+import {mapUserToListItem} from 'utils/mappers';
 
 const UserOverview = () => {
     const location = useLocation();
+    const user = useMemo(() => mapUserToListItem(location.state), [location.state]);
     return (
         <Container>
-            <Header
-                title={`User ${location.state.firstName} ${location.state.lastName}`}
-            />
-            {mapU(location.state)}
+            <Header title={`User ${location.state.firstName} ${location.state.lastName}`} />
+            <Card hasNavigation={false} columns={user.columns} />
         </Container>
     );
 };

--- a/src/pages/__tests__/testTeamOverview.tsx
+++ b/src/pages/__tests__/testTeamOverview.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {render, screen, waitFor} from '@testing-library/react';
 import * as API from '../../api';
 import TeamOverview from '../TeamOverview';

--- a/src/pages/__tests__/testTeamOverview.tsx
+++ b/src/pages/__tests__/testTeamOverview.tsx
@@ -1,7 +1,47 @@
-import React from 'react';
-import {render, screen, waitFor} from '@testing-library/react';
-import * as API from '../../api';
+import React, {ChangeEvent} from 'react';
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import TeamOverview from '../TeamOverview';
+import {getTeamOverview, getUserData} from '../../api';
+
+const mockUseNavigate = jest.fn();
+
+const teamOverview = {
+    id: 1,
+    teamLeadId: '2',
+    teamMemberIds: ['3', '4', '5'],
+};
+const userData1 = {
+    id: 1,
+    firstName: 'userData1',
+    lastName: 'userData1',
+    displayName: 'userData1',
+    location: '',
+    avatar: '',
+};
+const userData2 = {
+    id: 2,
+    firstName: 'userData2',
+    lastName: 'userData2',
+    displayName: 'userData2',
+    location: '',
+    avatar: '',
+};
+const userData3 = {
+    id: 3,
+    firstName: 'userData3',
+    lastName: 'userData3',
+    displayName: 'userData3',
+    location: '',
+    avatar: '',
+};
+const userData4 = {
+    id: 4,
+    firstName: 'userData4',
+    lastName: 'userData4',
+    displayName: 'userData4',
+    location: '',
+    avatar: '',
+};
 
 jest.mock('react-router-dom', () => ({
     useLocation: () => ({
@@ -9,10 +49,15 @@ jest.mock('react-router-dom', () => ({
             teamName: 'Some Team',
         },
     }),
-    useNavigate: () => ({}),
+    useNavigate: () => mockUseNavigate,
     useParams: () => ({
         teamId: '1',
     }),
+}));
+
+jest.mock('api', () => ({
+    getTeamOverview: jest.fn(),
+    getUserData: jest.fn(),
 }));
 
 describe('TeamOverview', () => {
@@ -28,27 +73,63 @@ describe('TeamOverview', () => {
         jest.useRealTimers();
     });
 
-    it('should render team overview users', async () => {
-        const teamOverview = {
-            id: '1',
-            teamLeadId: '2',
-            teamMemberIds: ['3', '4', '5'],
-        };
-        const userData = {
-            id: '2',
-            firstName: 'userData',
-            lastName: 'userData',
-            displayName: 'userData',
-            location: '',
-            avatar: '',
-        };
-        jest.spyOn(API, 'getTeamOverview').mockImplementationOnce(() => Promise.resolve({} as any));
-        jest.spyOn(API, 'getUserData').mockImplementationOnce(() => Promise.resolve({} as any));
+    beforeEach(() => {
+        jest.resetAllMocks();
+        (getTeamOverview as jest.Mock).mockResolvedValue(teamOverview);
+        (getUserData as jest.Mock)
+            .mockResolvedValueOnce(userData1)
+            .mockResolvedValueOnce(userData2)
+            .mockResolvedValueOnce(userData3)
+            .mockResolvedValueOnce(userData4);
+    });
 
+    it('should render team overview users', async () => {
         render(<TeamOverview />);
 
         await waitFor(() => {
-            expect(screen.queryAllByText('userData')).toHaveLength(4);
+            expect(screen.queryAllByText('Display Name')).toHaveLength(4);
         });
+    });
+
+    it('should not break if api fails', async () => {
+        render(<TeamOverview />);
+
+        await act(async () => {
+            (getTeamOverview as jest.Mock).mockRejectedValue({});
+            (getUserData as jest.Mock).mockRejectedValue({});
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByText('Team1')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should filter items when filter input is changed', async () => {
+        render(<TeamOverview />);
+
+        await waitFor(() => {
+            expect(screen.getByText('userData4')).toBeInTheDocument();
+        });
+        expect(screen.getByText('userData2')).toBeInTheDocument();
+
+        const filterInput = screen.getByLabelText('Search Team Member');
+        fireEvent.change(filterInput, {target: {value: '2'}} as ChangeEvent<HTMLInputElement>);
+
+        expect(screen.getByText('userData2')).toBeInTheDocument();
+        expect(screen.queryByText('userData4')).not.toBeInTheDocument();
+    });
+
+    it('should navigate when list emit an event from clicking a card', async () => {
+        render(<TeamOverview />);
+
+        await waitFor(() => {
+            expect(screen.getByText('userData4')).toBeInTheDocument();
+        });
+
+        const card = screen.getByText('userData4');
+        fireEvent.click(card);
+
+        expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+        expect(mockUseNavigate).toHaveBeenCalledWith('/user/4', {state: userData4});
     });
 });

--- a/src/pages/__tests__/testTeams.tsx
+++ b/src/pages/__tests__/testTeams.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, {ChangeEvent} from 'react';
 import {fireEvent, render, screen, waitFor, act} from '@testing-library/react';
-import * as API from '../../api';
 import Teams from '../Teams';
+import {getTeams as fetchTeams} from '../../api';
+
+const mockUseNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
     useLocation: () => ({
@@ -12,7 +14,11 @@ jest.mock('react-router-dom', () => ({
             location: 'location',
         },
     }),
-    useNavigate: () => ({}),
+    useNavigate: () => mockUseNavigate,
+}));
+
+jest.mock('api', () => ({
+    getTeams: jest.fn(),
 }));
 
 describe('Teams', () => {
@@ -28,12 +34,12 @@ describe('Teams', () => {
         jest.useRealTimers();
     });
 
-    it('should render spinner while loading', async () => {
-        // TODO - Add code for this test
+    beforeEach(() => {
+        jest.resetAllMocks();
     });
 
-    it('should render teams list', async () => {
-        jest.spyOn(API, 'getTeams').mockResolvedValue([
+    it('should render spinner while loading', async () => {
+        const mockTeams = [
             {
                 id: '1',
                 name: 'Team1',
@@ -42,7 +48,30 @@ describe('Teams', () => {
                 id: '2',
                 name: 'Team2',
             },
-        ]);
+        ];
+        (fetchTeams as jest.Mock).mockResolvedValue(mockTeams);
+        render(<Teams />);
+
+        expect(screen.getByTestId('spinner')).toBeInTheDocument();
+
+        await waitFor(() => {
+            expect(screen.getByText('Team1')).toBeInTheDocument();
+        });
+        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+    });
+
+    it('should render teams list', async () => {
+        const mockTeams = [
+            {
+                id: '1',
+                name: 'Team1',
+            },
+            {
+                id: '2',
+                name: 'Team2',
+            },
+        ];
+        (fetchTeams as jest.Mock).mockResolvedValue(mockTeams);
 
         render(<Teams />);
 
@@ -50,5 +79,69 @@ describe('Teams', () => {
             expect(screen.getByText('Team1')).toBeInTheDocument();
         });
         expect(screen.getByText('Team2')).toBeInTheDocument();
+    });
+
+    it('should not break if api fails', async () => {
+        render(<Teams />);
+
+        await act(async () => {
+            (fetchTeams as jest.Mock).mockRejectedValue([]);
+        });
+
+        await waitFor(() => {
+            expect(screen.queryByText('Team1')).not.toBeInTheDocument();
+        });
+    });
+
+    it('should filter items when filter input is changed', async () => {
+        const mockTeams = [
+            {
+                id: '1',
+                name: 'Team1',
+            },
+            {
+                id: '2',
+                name: 'Team2',
+            },
+        ];
+        (fetchTeams as jest.Mock).mockResolvedValue(mockTeams);
+
+        render(<Teams />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Team1')).toBeInTheDocument();
+        });
+
+        const filterInput = screen.getByLabelText('Search Project');
+        fireEvent.change(filterInput, {target: {value: '2'}} as ChangeEvent<HTMLInputElement>);
+
+        expect(screen.getByText('Team2')).toBeInTheDocument();
+        expect(screen.queryByText('Team1')).not.toBeInTheDocument();
+    });
+
+    it('should navigate when list emit an event from clicking a card', async () => {
+        const mockTeams = [
+            {
+                id: '1',
+                name: 'Team1',
+            },
+            {
+                id: '2',
+                name: 'Team2',
+            },
+        ];
+        (fetchTeams as jest.Mock).mockResolvedValue(mockTeams);
+
+        render(<Teams />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Team1')).toBeInTheDocument();
+        });
+
+        const teamCard = screen.getByText('Team1');
+        fireEvent.click(teamCard);
+
+        expect(mockUseNavigate).toHaveBeenCalledTimes(1);
+        expect(mockUseNavigate).toHaveBeenCalledWith('/team/1', {state: {id: '1', name: 'Team1'}});
     });
 });

--- a/src/pages/__tests__/testTeams.tsx
+++ b/src/pages/__tests__/testTeams.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import {fireEvent, render, screen, waitFor, act} from '@testing-library/react';
 import * as API from '../../api';
 import Teams from '../Teams';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,31 +1,3 @@
-export interface Teams {
-    id: string;
-    name: string;
-}
-
-export interface TeamOverview {
-    id: string;
-    teamLeadId: string;
-    teamMemberIds: string[];
-}
-
-export interface UserData {
-    id: string;
-    firstName: string;
-    lastName: string;
-    displayName: string;
-    location: string;
-    avatar: string;
-}
-
-export interface ListItemColumn {
-    key: string;
-    value: string;
-}
-
-export interface ListItem {
-    id: string;
-    url?: string;
-    columns: Array<ListItemColumn>;
-    navigationProps?: UserData | Teams;
-}
+export * from './list';
+export * from './team';
+export * from './user';

--- a/src/types/list.ts
+++ b/src/types/list.ts
@@ -1,0 +1,14 @@
+import {Teams} from './team';
+import {UserData} from './user';
+
+export interface ListItemColumn {
+    key: string;
+    value: string;
+}
+
+export interface ListItem {
+    id: string;
+    url?: string;
+    columns: Array<ListItemColumn>;
+    navigationProps?: UserData | Teams;
+}

--- a/src/types/team.ts
+++ b/src/types/team.ts
@@ -1,0 +1,10 @@
+export interface Teams {
+    id: string;
+    name: string;
+}
+
+export interface TeamOverview {
+    id: string;
+    teamLeadId: string;
+    teamMemberIds: string[];
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,8 @@
+export interface UserData {
+    id: string;
+    firstName: string;
+    lastName: string;
+    displayName: string;
+    location: string;
+    avatar: string;
+}

--- a/src/utils/httpRequest.ts
+++ b/src/utils/httpRequest.ts
@@ -1,0 +1,7 @@
+export const fetchData = async (path = '') => {
+    const url = `${process.env.REACT_APP_API_BASE_URL}/${path}`;
+    const res = await fetch(url);
+    const json = await res.json();
+
+    return json;
+};

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -1,0 +1,44 @@
+import {ListItem, UserData, Teams as TeamsList} from 'types';
+
+export const mapUserToListItem = (userData: UserData): ListItem => {
+    if (!userData) {
+        return {} as ListItem;
+    }
+    const columns = [
+        {
+            key: 'Name',
+            value: `${userData.firstName} ${userData.lastName}`,
+        },
+        {
+            key: 'Display Name',
+            value: userData.displayName,
+        },
+        {
+            key: 'Location',
+            value: userData.location,
+        },
+    ];
+    return {
+        id: userData.id,
+        url: `/user/${userData.id}`,
+        columns,
+        navigationProps: userData,
+    };
+};
+
+export const mapTeamsToListItem = (teams: TeamsList[]) => {
+    return teams.map(team => {
+        const columns = [
+            {
+                key: 'Name',
+                value: team.name,
+            },
+        ];
+        return {
+            id: team.id,
+            url: `/team/${team.id}`,
+            columns,
+            navigationProps: team,
+        } as ListItem;
+    });
+};

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -27,18 +27,20 @@ export const mapUserToListItem = (userData: UserData): ListItem => {
 };
 
 export const mapTeamsToListItem = (teams: TeamsList[]) => {
-    return teams.map(team => {
-        const columns = [
-            {
-                key: 'Name',
-                value: team.name,
-            },
-        ];
-        return {
-            id: team.id,
-            url: `/team/${team.id}`,
-            columns,
-            navigationProps: team,
-        } as ListItem;
-    });
+    return (
+        teams?.map(team => {
+            const columns = [
+                {
+                    key: 'Name',
+                    value: team.name,
+                },
+            ];
+            return {
+                id: team.id,
+                url: `/team/${team.id}`,
+                columns,
+                navigationProps: team,
+            } as ListItem;
+        }) ?? []
+    );
 };


### PR DESCRIPTION
The main change that I did in this code was isolate components to be as dumb as possible. This way they can easily reused in other locations. To do this I move all the logic (event with router) to outside a keep all logic inside the pages.

Some other changes is for example separate files for context, giving a better isolation. For example with types, where the index now just export the types from others files, like list, team, user. Another example is with `api` folder, where I isolated by context, in this case `users` and `teams`.

Another change was create a helper folder called `utils`, where I moved code that was used in more than one place, for example mappers used to convert `User `or `Teams `to `ListItem`.

For create a new component I used a simple `input `that fires an event every change typed there. In this case I believe this was enough since I changed some calculations to `useMemo` and a new request is not send every change. In case this was necessary, I think a debounce should be applied to this avoiding unecessary requests.

More details I will comment on the changes writing why I did it.